### PR TITLE
#14 Use new avatar component in party card

### DIFF
--- a/libs/gloomhaven-party-components/src/lib/gloomhaven-parties/gloomhaven-parties.component.stories.ts
+++ b/libs/gloomhaven-party-components/src/lib/gloomhaven-parties/gloomhaven-parties.component.stories.ts
@@ -16,6 +16,7 @@ import { MatIconRegistryModule } from "../../../../common-components/src";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { MatButtonModule } from "@angular/material/button";
+import { GloomhavenAvatarComponent } from "../gloomhaven-avatar/gloomhaven-avatar.component";
 
 export default {
   title: "GloomhavenPartiesComponent",
@@ -131,6 +132,7 @@ const Template = (args: GloomhavenPartiesComponent & { name: string }) => {
   return {
     moduleMetadata: {
       declarations: [
+        GloomhavenAvatarComponent,
         GloomhavenPartyCardComponent
       ],
       imports: [

--- a/libs/gloomhaven-party-components/src/lib/gloomhaven-party-card/gloomhaven-party-card.component.html
+++ b/libs/gloomhaven-party-components/src/lib/gloomhaven-party-card/gloomhaven-party-card.component.html
@@ -14,7 +14,7 @@
     <mat-divider [vertical]="true"></mat-divider>
     <mat-card class="hero" *ngFor="let hero of party.members">
       <mat-card-header>
-        <div mat-card-avatar class="character-avatar-{{hero.type.name}} mat-card-avatar"></div>
+        <ght-avatar [name]="hero.type.name"></ght-avatar>
         <mat-card-title>{{hero.name}}</mat-card-title>
         <mat-card-subtitle>{{hero.type.name}}</mat-card-subtitle>
         <mat-card-subtitle class="hero-attributes">

--- a/libs/gloomhaven-party-components/src/lib/gloomhaven-party-card/gloomhaven-party-card.component.stories.ts
+++ b/libs/gloomhaven-party-components/src/lib/gloomhaven-party-card/gloomhaven-party-card.component.stories.ts
@@ -14,6 +14,7 @@ import { MatIconRegistryModule } from "../../../../common-components/src";
 import { MatDividerModule } from "@angular/material/divider";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { GloomhavenAvatarComponent } from "../gloomhaven-avatar/gloomhaven-avatar.component";
 
 export default {
   title: "GloomhavenPartyCardComponent",
@@ -73,6 +74,9 @@ const party: GloomhavenParty = {
 
 export const PartyCard = () =>({
   moduleMetadata: {
+    declarations: [
+      GloomhavenAvatarComponent
+    ],
     imports: [
       BrowserAnimationsModule,
       MatCardModule,


### PR DESCRIPTION
Use new avatar component to use only one component
with this functionality. It is easier to maintain
only one component

close #14 