### PR TITLE
#51 Use uuid for campaign/party

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -339,6 +339,31 @@
           }
         }
       }
+    },
+    "common-services": {
+      "projectType": "library",
+      "root": "libs/common-services",
+      "sourceRoot": "libs/common-services/src",
+      "prefix": "gloomhaven-tracker",
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/common-services/src/**/*.ts",
+              "libs/common-services/src/**/*.html"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/common-services"],
+          "options": {
+            "jestConfig": "libs/common-services/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
     }
   },
   "cli": {

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,5 @@ module.exports = {
   resolver: '@nrwl/jest/plugins/resolver',
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageReporters: ['html'],
-  projects: '<rootDir>/libs/persistence',
+  projects: '<rootDir>/libs/common-services',
 };

--- a/libs/api-interfaces/src/lib/campaign/campaign.model.ts
+++ b/libs/api-interfaces/src/lib/campaign/campaign.model.ts
@@ -6,6 +6,7 @@ export interface Gloomhaven {
 }
 
 export interface GloomhavenCampaign {
+  uid: string;
   gloomhaven: Gloomhaven;
   party: GloomhavenParty;
 }

--- a/libs/common-services/.eslintrc.json
+++ b/libs/common-services/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "parserOptions": { "project": ["libs/common-services/tsconfig.*?.json"] },
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "gloomhaven-tracker",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "gloomhaven-tracker",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/common-services/README.md
+++ b/libs/common-services/README.md
@@ -1,0 +1,7 @@
+# common-services
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test common-services` to execute the unit tests.

--- a/libs/common-services/jest.config.js
+++ b/libs/common-services/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  displayName: 'common-services',
+  preset: '../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ],
+      },
+    },
+  },
+  coverageDirectory: '../../coverage/libs/common-services',
+  snapshotSerializers: [
+    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
+    'jest-preset-angular/build/AngularSnapshotSerializer.js',
+    'jest-preset-angular/build/HTMLCommentSerializer.js',
+  ],
+};

--- a/libs/common-services/src/index.ts
+++ b/libs/common-services/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/uuid/uuid.service';
+export * from './lib/common-services.module';

--- a/libs/common-services/src/lib/common-services.module.ts
+++ b/libs/common-services/src/lib/common-services.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {UUIDService} from './uuid/uuid.service';
+
+@NgModule({
+  imports: [CommonModule],
+  providers: [UUIDService]
+})
+export class CommonServicesModule {}

--- a/libs/common-services/src/lib/uuid/uuid.service.ts
+++ b/libs/common-services/src/lib/uuid/uuid.service.ts
@@ -1,0 +1,11 @@
+import {Injectable} from '@angular/core';
+import {v4} from 'uuid';
+
+@Injectable()
+export class UUIDService {
+
+  public uuid4(): string {
+    return v4()
+  }
+
+}

--- a/libs/common-services/src/test-setup.ts
+++ b/libs/common-services/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular';

--- a/libs/common-services/tsconfig.json
+++ b/libs/common-services/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/common-services/tsconfig.lib.json
+++ b/libs/common-services/tsconfig.lib.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/common-services/tsconfig.spec.json
+++ b/libs/common-services/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/gloomhaven-party-components/src/lib/gloomhaven-parties/gloomhaven-parties.component.html
+++ b/libs/gloomhaven-party-components/src/lib/gloomhaven-parties/gloomhaven-parties.component.html
@@ -1,5 +1,5 @@
 <div class="parties-container">
-  <div class="party" *ngFor="let campaign of campaigns; index as id">
+  <div class="party" *ngFor="let campaign of campaigns">
     <mat-card #card (click)="selectPartyClicked($event, campaign)">
       <mat-card-header class="party-info">
         <mat-card-title class="party-name">{{campaign.party.name}}</mat-card-title>
@@ -15,7 +15,7 @@
         </mat-card-subtitle>
       </mat-card-header>
     </mat-card>
-    <div class="delete-action" (click)="deletePartyClicked($event, campaign, id)">
+    <div class="delete-action" (click)="deletePartyClicked($event, campaign)">
       <mat-icon>delete</mat-icon>
     </div>
   </div>

--- a/libs/gloomhaven-party-components/src/lib/gloomhaven-parties/gloomhaven-parties.component.ts
+++ b/libs/gloomhaven-party-components/src/lib/gloomhaven-parties/gloomhaven-parties.component.ts
@@ -35,7 +35,7 @@ export class GloomhavenPartiesComponent {
   selectedCampaign: EventEmitter<GloomhavenCampaign | null> = new EventEmitter<GloomhavenCampaign | null>();
 
   @Output()
-  deleteCampaign: EventEmitter<number> = new EventEmitter<number>();
+  deleteCampaign: EventEmitter<string> = new EventEmitter<string>();
 
   @ViewChildren("card, addNew", { read: ElementRef }) cardRefs: QueryList<ElementRef>;
 
@@ -56,7 +56,7 @@ export class GloomhavenPartiesComponent {
     this.addParty.emit(activated);
   }
 
-  deletePartyClicked($event: MouseEvent, party: GloomhavenCampaign, id: number) {
+  deletePartyClicked($event: MouseEvent, party: GloomhavenCampaign) {
     const deleteDialog = this.dialog.open(DeletePartyDialogComponent, {
       data: party
     });
@@ -64,7 +64,7 @@ export class GloomhavenPartiesComponent {
     deleteDialog.afterClosed()
       .subscribe(confirmed => {
         if (confirmed) {
-          this.deleteCampaign.emit(id);
+          this.deleteCampaign.emit(party.uid);
         }
       });
   }

--- a/libs/persistence/src/index.ts
+++ b/libs/persistence/src/index.ts
@@ -1,1 +1,2 @@
+export * from './lib/party-storage.service';
 export * from './lib/persistence.module';

--- a/libs/persistence/src/lib/party-storage.service.spec.ts
+++ b/libs/persistence/src/lib/party-storage.service.spec.ts
@@ -6,6 +6,7 @@ describe('PartyStorageService', () => {
   let service: PartyStorageService;
   let storageStub: any;
   let testScheduler: TestScheduler;
+  const NIL_UUID = '00000000-0000-0000-0000-000000000000';
 
   beforeEach(() => {
     storageStub = {
@@ -15,7 +16,7 @@ describe('PartyStorageService', () => {
 
     storageStub.set.mockImplementation(() => of(undefined));
 
-    service = new PartyStorageService(storageStub);
+    service = new PartyStorageService(storageStub, { uuid4: () => NIL_UUID });
     testScheduler = new TestScheduler((actual, expected) => {
       expect(actual).toEqual(expected);
     });
@@ -27,6 +28,7 @@ describe('PartyStorageService', () => {
       storageStub.get.mockImplementation(() => of(undefined));
 
       const expectedCampaigns = [{
+        uid: NIL_UUID,
         gloomhaven: {
           prosperity: 0,
           achievements: []
@@ -44,10 +46,10 @@ describe('PartyStorageService', () => {
 
       testScheduler.run(({expectObservable, flush}) => {
         expectObservable(service.createParty('first party')).toBe('(a|)', {
-          a: undefined
+          a: NIL_UUID
         });
         flush();
-        expect(storageStub.get).toBeCalledWith('campaigns', expect.anything());
+        expect(storageStub.get).toBeCalledWith('campaigns');
         expect(storageStub.set).toBeCalledWith('campaigns', expectedCampaigns);
       });
     });
@@ -55,6 +57,7 @@ describe('PartyStorageService', () => {
     it('should add party with name', () => {
       storageStub.get.mockImplementation(() => of([
         {
+          uid: NIL_UUID,
           gloomhaven: {
             prosperity: 0,
             achievements: []
@@ -73,6 +76,7 @@ describe('PartyStorageService', () => {
 
       const expectedCampaigns = [
         {
+          uid: NIL_UUID,
           gloomhaven: {
             prosperity: 0,
             achievements: []
@@ -88,27 +92,28 @@ describe('PartyStorageService', () => {
           }
         },
         {
-        gloomhaven: {
-          prosperity: 0,
-          achievements: []
-        },
-        party: {
-          name: 'test party',
-          reputation: 0,
-          achievements: [],
-          currentLocation: {
-            name: 'Gloomhaven'
+          uid: NIL_UUID,
+          gloomhaven: {
+            prosperity: 0,
+            achievements: []
           },
-          members: []
-        }
+          party: {
+            name: 'test party',
+            reputation: 0,
+            achievements: [],
+            currentLocation: {
+              name: 'Gloomhaven'
+            },
+            members: []
+          }
       }];
 
       testScheduler.run(({expectObservable, flush}) => {
         expectObservable(service.createParty('test party')).toBe('(a|)', {
-          a: undefined
+          a: NIL_UUID
         });
         flush();
-        expect(storageStub.get).toBeCalledWith('campaigns', expect.anything());
+        expect(storageStub.get).toBeCalledWith('campaigns');
         expect(storageStub.set).toBeCalledWith('campaigns', expectedCampaigns);
       });
     });
@@ -117,28 +122,15 @@ describe('PartyStorageService', () => {
 
   describe('deleteParty', () => {
 
-    it('should return error when negative value', () => {
-      storageStub.get.mockImplementation(() => of(undefined));
-
-      testScheduler.run(({expectObservable, flush}) => {
-        expectObservable(service.deleteParty(-1)).toBe('(a|)', {
-          a: 'Unable to remove non existing element. Negative value'
-        });
-        flush();
-        expect(storageStub.get).not.toBeCalled();
-        expect(storageStub.set).not.toBeCalled();
-      });
-    });
-
     it('should return error when higher value', () => {
       storageStub.get.mockImplementation(() => of(undefined));
 
       testScheduler.run(({expectObservable, flush}) => {
-        expectObservable(service.deleteParty(3)).toBe('(a|)', {
-          a: 'Unable to remove non existing element. Index out of bounds'
+        expectObservable(service.deleteParty('13')).toBe('(a|)', {
+          a: 'Unable to remove non existing element'
         });
         flush();
-        expect(storageStub.get).toBeCalledWith('campaigns', expect.anything());
+        expect(storageStub.get).toBeCalledWith('campaigns');
         expect(storageStub.set).not.toBeCalled();
       });
     });
@@ -147,6 +139,7 @@ describe('PartyStorageService', () => {
       storageStub.get.mockImplementation(() => of(
         [
           {
+            uid: NIL_UUID,
             gloomhaven: {
               prosperity: 0,
               achievements: []
@@ -162,6 +155,7 @@ describe('PartyStorageService', () => {
             }
           },
           {
+            uid: '13',
             gloomhaven: {
               prosperity: 0,
               achievements: []
@@ -179,6 +173,7 @@ describe('PartyStorageService', () => {
       ));
 
       const expectedCampaigns = [{
+        uid: NIL_UUID,
         gloomhaven: {
           prosperity: 0,
           achievements: []
@@ -195,11 +190,11 @@ describe('PartyStorageService', () => {
       }];
 
       testScheduler.run(({expectObservable, flush}) => {
-        expectObservable(service.deleteParty(1)).toBe('(a|)', {
+        expectObservable(service.deleteParty('13')).toBe('(a|)', {
           a: undefined
         });
         flush();
-        expect(storageStub.get).toBeCalledWith('campaigns', expect.anything());
+        expect(storageStub.get).toBeCalledWith('campaigns');
         expect(storageStub.set).toBeCalledWith('campaigns', expectedCampaigns);
       });
     });

--- a/libs/persistence/src/lib/persistence.module.ts
+++ b/libs/persistence/src/lib/persistence.module.ts
@@ -2,11 +2,13 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {StorageModule} from '@ngx-pwa/local-storage';
 import {PartyStorageService} from './party-storage.service';
+import {CommonServicesModule} from '@gloomhaven-tracker/common-services';
 
 @NgModule({
   imports: [
     CommonModule,
-    StorageModule
+    StorageModule,
+    CommonServicesModule
   ],
   providers: [
     PartyStorageService

--- a/nx.json
+++ b/nx.json
@@ -29,6 +29,7 @@
     "common-library": { "tags": [] },
     "gloomhaven-party-components": { "tags": [] },
     "common-components": { "tags": [] },
-    "persistence": { "tags": [] }
+    "persistence": { "tags": [] },
+    "common-services": { "tags": [] }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@angular/router": "11.1.1",
     "@ngx-pwa/local-storage": "11.1.0",
     "@nrwl/angular": "11.2.6",
+    "uuid": "8.3.2",
     "rxjs": "6.6.3",
     "tslib": "^2.0.0",
     "zone.js": "0.11.3"
@@ -81,6 +82,7 @@
     "@storybook/angular": "6.1.15",
     "@types/jest": "26.0.8",
     "@types/node": "12.12.38",
+    "@types/uuid": "8.3.0",
     "@typescript-eslint/eslint-plugin": "4.3.0",
     "@typescript-eslint/parser": "4.3.0",
     "codelyzer": "6.0.1",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,7 +28,10 @@
       "@gloomhaven-tracker/common-components": [
         "libs/common-components/src/index.ts"
       ],
-      "@gloomhaven-tracker/persistence": ["libs/persistence/src/index.ts"]
+      "@gloomhaven-tracker/persistence": ["libs/persistence/src/index.ts"],
+      "@gloomhaven-tracker/common-services": [
+        "libs/common-services/src/index.ts"
+      ]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3568,6 +3568,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/uuid@8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/webpack-env@^1.15.3":
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.0.tgz#8c0a9435dfa7b3b1be76562f3070efb3f92637b4"
@@ -15863,6 +15868,11 @@ uuid@8.3.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
+uuid@8.3.2, uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 uuid@^3.0.0, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -15872,11 +15882,6 @@ uuid@^8.0.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"


### PR DESCRIPTION
Update party service to generate and use uuid
so party/campaign can be easily deleted and fetched
also within the routing